### PR TITLE
Use provider.stage instead of defaults.stage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,10 +26,9 @@ module.exports = Class.extend({
 */
 
     // find the correct stage name
-    var stage = this._serverless.service.defaults.stage;
-    if (this._serverless.variables.options.stage) {
-      stage = this._serverless.variables.options.stage;
-    }
+    const stage = this._serverless.variables.options.stage ?
+      this._serverless.variables.options.stage :
+      this._serverless.service.provider.stage;
 
     // override the deployment config, which can be ignored, see:
     // http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigateway-deployment.html


### PR DESCRIPTION
The serverless framework dropped the use of defaults in lieu of provider.
This caused the deploy to break.

I only touched index.js, so you'll have to bump the version in package.json. I recommend 2.0.0 since this is a breaking change.