### PR TITLE
Remove Lodash full && Add lodash merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     }
   ],
   "dependencies": {
-    "lodash": "4.17.2",
-    "class.extend": "0.9.2"
+    "class.extend": "0.9.2",
+    "lodash.merge": "4.6.1"
   },
   "license": "MIT",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const _ = require('lodash');
+const merge = require('lodash.merge');
 const Class = require('class.extend');
 
 module.exports = Class.extend({
@@ -63,7 +63,7 @@ module.exports = Class.extend({
         // add stage config
         stageConfig.Properties.DeploymentId = {"Ref":key}
         if (template.Resources.ApiGatewayStage) {
-          _.merge(template.Resources.ApiGatewayStage, stageConfig);
+          merge(template.Resources.ApiGatewayStage, stageConfig);
         } else {
           template.Resources.ApiGatewayStage = stageConfig;
         }


### PR DESCRIPTION
Before the package was importing the entire lodash library and that's a pretty big library.
Now the package was change to include only the function that's being used.

That should give a small performance boost in install time, execution time and memory usage.

It's also worth to mention that `npm audit` does a lot of alerts because of lodash. This also fixes the npm audit alerts and security issues.

## before
```
 $ npm audit

                       === npm audit security report ===

┌──────────────────────────────────────────────────────────────────────────────┐
│                                Manual Review                                 │
│            Some vulnerabilities require your attention to resolve            │
│                                                                              │
│         Visit https://go.npm.me/audit-guide for additional guidance          │
└──────────────────────────────────────────────────────────────────────────────┘
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ lodash                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=4.17.5                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ serverless-enable-api-logs [dev]                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ serverless-enable-api-logs > lodash                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/577                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
  1 vulnerability requires manual review. See the full report for details.
```

## After
```
$ npm audit

                       === npm audit security report ===

found 0 vulnerabilities
 in 2 scanned packages
```

Signed-off-by: Luan <luan@luanmuniz.com.br>